### PR TITLE
fix-renderエラー

### DIFF
--- a/bin/render-entrypoint.sh
+++ b/bin/render-entrypoint.sh
@@ -1,8 +1,26 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # exit on error
 set -o errexit
 
 rm -f /app/tmp/pids/server.pid
+
+echo "Waiting for database to be ready..."
+ruby -r pg -e "
+  retries = 5
+  begin
+    PG.connect(ENV['DATABASE_URL'])
+    puts 'Database is ready!'
+  rescue PG::ConnectionBad
+    puts 'Database not ready yet, retrying...'
+    retries -= 1
+    if retries > 0
+      sleep 5
+      retry
+    else
+      exit 1
+    end
+  end
+"
 
 echo "Running database migrations..."
 bundle exec rails db:migrate


### PR DESCRIPTION
## 概要
RenderがWebサービス（historia-staging）とデータベース（historia-db）を同時に起動しようとしており、タイミングで問題が出たため、DBの準備ができるまで待つスクリプトを実装しました。