### PR TITLE
fix-historia-staging.onrender.com からのアクセス許可

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,4 +102,6 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.hosts << "historia.onrender.com"
+  config.hosts << "historia-staging.onrender.com"
 end


### PR DESCRIPTION
## 概要
historia-staging.onrender.comがデプロイできましたが、アクセス許可されていなかったため許可しました。