### PR TITLE
update-CICDチェックの連動

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,3 +192,13 @@ jobs:
           name: screenshots
           path: ${{ github.workspace }}/tmp/screenshots
           if-no-files-found: ignore
+
+deploy-staging:
+    runs-on: ubuntu-latest
+    needs: [scan_ruby, scan_js_audit, lint, test]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+    steps:
+      - name: Trigger Render Staging Deploy
+        run: curl -X POST ${{ secrets.RENDER_STAGING_DEPLOY_HOOK_URL }}
+        


### PR DESCRIPTION
## 概要
以前だと、マージしたらCIチェックのいかんにかかわらず、無条件でデプロイが始まっていた。
こんかいの変更により、 マージ後、テストが全て成功した場合にのみデプロイが始まるようにした。