### PR TITLE
update-公開ストーリーの削除のみ背景適用不可

### DIFF
--- a/app/views/stories/_story.html.erb
+++ b/app/views/stories/_story.html.erb
@@ -36,7 +36,7 @@
               modal_body: "「<strong>#{story.title}</strong>」を完全に削除します。この操作は元に戻せません。",
               modal_button_text: "削除する"
             },
-            class: "text-white bg-black rounded-md px-2 py-0.5 text-xs transition-colors md:text-gray-700 md:bg-transparent md:border md:border-gray-400 md:hover:bg-red-500 md:hover:text-white" %>
+            class: "text-white bg-black rounded-md px-2 py-0.5 text-xs transition-colors md:text-gray-700 md:bg-white md:border md:border-gray-400 md:hover:bg-red-500 md:hover:text-white" %>
     </div>
   </div>
 


### PR DESCRIPTION
## 概要
ストーリーカードが公開ステータスに変更したときの削除ボタンの背景を白色に統一しました。