### PR TITLE
add-イメージ画像バリデーション

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update -qq && \
         gnupg \
         chromium \
         chromium-driver \
+        libvips-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -29,6 +30,7 @@ RUN apt-get update -qq && \
         ca-certificates \
         curl \
         gnupg \
+        libvips-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/Gemfile
+++ b/Gemfile
@@ -51,8 +51,10 @@ gem "tailwindcss-rails", "~> 3.3.1"
 
 gem "cloudinary"
 
+gem "active_storage_validations"
+gem "image_processing", "~> 1.2"
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
+
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,12 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_storage_validations (3.0.1)
+      activejob (>= 6.1.4)
+      activemodel (>= 6.1.4)
+      activestorage (>= 6.1.4)
+      activesupport (>= 6.1.4)
+      marcel (>= 1.0.3)
     activejob (7.2.2.1)
       activesupport (= 7.2.2.1)
       globalid (>= 0.3.6)
@@ -134,6 +140,7 @@ GEM
       multipart-post (~> 2.0)
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
+    ffi (1.17.2-x86_64-linux-gnu)
     foreman (0.88.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -143,6 +150,9 @@ GEM
     hashie (5.0.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    image_processing (1.14.0)
+      mini_magick (>= 4.9.5, < 6)
+      ruby-vips (>= 2.0.17, < 3)
     importmap-rails (2.1.0)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -181,6 +191,8 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.3)
+    mini_magick (5.3.0)
+      logger
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
@@ -339,6 +351,9 @@ GEM
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.2.4)
+      ffi (~> 1.12)
+      logger
     rubyzip (2.4.1)
     securerandom (0.4.1)
     selenium-webdriver (4.34.0)
@@ -397,6 +412,7 @@ PLATFORMS
   x86_64-linux-gnu
 
 DEPENDENCIES
+  active_storage_validations
   bootsnap
   brakeman
   capybara
@@ -408,6 +424,7 @@ DEPENDENCIES
   faker
   foreman
   gretel
+  image_processing (~> 1.2)
   importmap-rails
   jbuilder
   letter_opener_web (~> 1.4)

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -4,6 +4,10 @@ class Character < ApplicationRecord
   belongs_to :address_world_guide, class_name: "WorldGuide", optional: true
 
   has_one_attached :image
+  validates :image, content_type: { in: [ "image/jpeg", "image/png" ], message: "のファイル形式はJPEGまたはPNGにしてください" },
+                    size: { less_than: 5.megabytes, message: "のファイルサイズは5MB以下にしてください" }
+
+  after_save :process_image_variants, if: -> { image.attached? && image.changed? }
 
   has_many :character_features, dependent: :destroy
   has_many :character_feature_categories, through: :character_features
@@ -36,4 +40,12 @@ class Character < ApplicationRecord
   validates :name, presence: true, length: { maximum: 30 }
   validates :race, length: { maximum: 30 }
   validates :age, length: { maximum: 20 }
+
+  private
+
+  def process_image_variants
+    image.variant(resize_to_limit: [ 1200, 1200 ]).processed
+    image.variant(resize_to_limit: [ 800, 800 ]).processed
+    image.variant(resize_to_fill: [ 128, 128 ]).processed
+  end
 end

--- a/app/models/world_guide.rb
+++ b/app/models/world_guide.rb
@@ -9,6 +9,10 @@ class WorldGuide < ApplicationRecord
   accepts_nested_attributes_for :world_guide_features, allow_destroy: true, reject_if: :all_blank
 
   has_one_attached :image
+  validates :image, content_type: { in: [ "image/jpeg", "image/png" ], message: "のファイル形式はJPEGまたはPNGにしてください" },
+                    size: { less_than: 5.megabytes, message: "のファイルサイズは5MB以下にしてください" }
+
+  after_save :process_image_variants, if: -> { image.attached? && image.changed? }
 
   enum category: {
     "現在" => "現在",
@@ -28,4 +32,12 @@ class WorldGuide < ApplicationRecord
   validates :world_name, length: { maximum: 20 }
   validates :country_name, presence: true, length: { maximum: 20 }
   validates :region_name, presence: true, length: { maximum: 20 }
+
+  private
+
+  def process_image_variants
+    image.variant(resize_to_limit: [ 1200, 1200 ]).processed
+    image.variant(resize_to_limit: [ 800, 800 ]).processed
+    image.variant(resize_to_fill: [ 128, 128 ]).processed
+  end
 end

--- a/app/views/characters/details/_character_info_card.html.erb
+++ b/app/views/characters/details/_character_info_card.html.erb
@@ -51,14 +51,16 @@
 
     <div>
       <p class="font-bold">【イメージ画像】</p>
-      <% if character.image.attached? %>
-        <div class="ml-4 mt-4">
-          <a href="#" data-action="click->image-viewer#open" data-image-viewer-src-param="<%= url_for(character.image) %>">
-            <%= image_tag character.image, class: "w-48 h-48 object-cover rounded-lg shadow-md cursor-pointer" %>
+      <div class="mt-2">
+        <% if character.image.attached? %>
+          <a href="#" 
+             data-action="click->image-viewer#open" 
+             data-image-viewer-src-param="<%= url_for(character.image.variant(resize_to_limit: [1200, 1200])) %>">
+            <%= image_tag character.image.variant(resize_to_limit: [800, 800]), class: "w-full h-auto rounded-lg shadow-md cursor-pointer hover:opacity-80 transition-opacity" %>
           </a>
-        </div>
-      <% else %>
-        <p class="ml-4 mt-2">なし</p>
-      <% end %>
+        <% else %>
+          <p class="text-xl ml-4 mt-2">なし</p>
+        <% end %>
+      </div>
     </div>
 </div>

--- a/app/views/characters/forms/_image_upload_section.html.erb
+++ b/app/views/characters/forms/_image_upload_section.html.erb
@@ -1,10 +1,15 @@
 <div data-controller="image-preview">
   <p class="block text-lg font-bold">イメージ画像</p>
+
   <div class="flex gap-4 mt-3 mb-10">
-    <%= f.label :image, "ファイルから画像を追加", class: "w-1/2 py-2 text-center border border-gray-400 rounded-md cursor-pointer font-semibold hover:bg-black hover:text-white transition-colors" %>
-    <%= f.file_field :image, class: "hidden", data: { image_preview_target: "input", action: "change->image-preview#preview" } %>
-    
-    <button type="button" disabled class="w-1/2 py-2 border border-gray-400 rounded-md bg-gray-100 font-semibold text-gray-500">イメージ画像を見つける</button>
+    <div class="w-1/2">
+      <%= f.label :image, "ファイルから画像を追加", class: "w-full py-2 text-center border border-gray-400 rounded-md cursor-pointer font-semibold hover:bg-black hover:text-white transition-colors block" %>
+      <%= f.file_field :image, class: "hidden", data: { image_preview_target: "input", action: "change->image-preview#preview" } %>
+    </div>
+
+    <div class="w-1/2">
+      <button type="button" disabled class="w-full py-2 border border-gray-400 rounded-md bg-gray-100 font-semibold text-gray-500">イメージ画像を見つける</button>
+    </div>
   </div>
 
   <div class="mt-4">

--- a/app/views/characters/show.html.erb
+++ b/app/views/characters/show.html.erb
@@ -1,4 +1,11 @@
 <% breadcrumb :character, @story, @character %>
+
+<% if @character.image.attached? %>
+  <% content_for :head do %>
+    <link rel="preload" as="image" href="<%= url_for(@character.image.variant(resize_to_limit: [1200, 1200])) %>">
+  <% end %>
+<% end %>
+
 <div class="px-4 sm:px-6 lg:px-8 py-8">
   <div class="max-w-screen-xl mx-auto">
     <h1 class="text-center text-3xl md:text-4xl font-bold tracking-tight mt-12 mb-14">キャラクターを確認しよう！</h1>

--- a/app/views/shared/_image_viewer_modal.html.erb
+++ b/app/views/shared/_image_viewer_modal.html.erb
@@ -1,26 +1,31 @@
-<div>
-  <div data-image-viewer-target="container" class="hidden">
-    <div class="fixed inset-0 bg-black bg-opacity-30 z-50" data-action="click->image-viewer#close"></div>
-    <div class="fixed inset-0 flex items-center justify-center z-50 p-4 pointer-events-none">
-      
-<!-- モーダルカード（Stimulusのターゲットとして設定） -->
-      <div data-image-viewer-target="card" class="bg-white rounded-lg shadow-xl w-full max-w-4xl max-h-[90vh] flex flex-col pointer-events-auto" 
-           data-action="click->image-viewer#preventClose">
+<div data-image-viewer-target="container" class="hidden">
 
-<!-- モーダルヘッダー（ドラッグハンドルとして設定） -->
-        <div data-image-viewer-target="handle" class="flex justify-between items-center p-4 border-b cursor-grab" data-action="mousedown->image-viewer#startDrag">
-          <h3 class="text-lg font-semibold">イメージ画像</h3>
-          <button data-action="click->image-viewer#close" class="text-gray-500 hover:text-gray-800 text-2xl leading-none cursor-pointer">&times;</button>
-        </div>
+  <%# モーダルの背景（オーバーレイ） %>
+  <div class="fixed inset-0 bg-black bg-opacity-75 z-50" data-action="click->image-viewer#close"></div>
 
-<!-- モーダルボディ（画像を表示する） -->
-        <div class="p-4 overflow-hidden flex-grow flex items-center justify-center">
-          <img src="" 
-               data-image-viewer-target="image" 
-               class="max-w-full max-h-full object-contain">
-        </div>
+  <%# モーダルウィンドウの位置決め用ラッパー %>
+  <div class="fixed inset-0 flex items-center justify-center z-50 p-4 pointer-events-none">
+    
+    <%# モーダルカード本体 %>
+    <div data-image-viewer-target="card" 
+         class="bg-white rounded-lg shadow-xl flex flex-col max-h-[90vh] pointer-events-auto" 
+         data-action="click->image-viewer#preventClose">
 
+      <%# モーダルヘッダー（ドラッグハンドル） %>
+      <div data-image-viewer-target="handle" 
+           class="flex-shrink-0 flex justify-between items-center p-4 border-b cursor-grab" 
+           data-action="mousedown->image-viewer#startDrag">
+        <h3 class="text-lg font-semibold">イメージ画像</h3>
+        <button data-action="click->image-viewer#close" class="text-gray-500 hover:text-gray-800 text-2xl leading-none cursor-pointer">&times;</button>
       </div>
+
+      <%# モーダルボディ（画像） %>
+      <div class="p-4 overflow-auto flex-grow flex items-center justify-center">
+        <img src="" 
+             data-image-viewer-target="image" 
+             class="object-contain max-w-[90vw] max-h-[calc(90vh-100px)]">
+      </div>
+
     </div>
   </div>
 </div>

--- a/app/views/world_guides/_details.html.erb
+++ b/app/views/world_guides/_details.html.erb
@@ -31,13 +31,15 @@
 
   <div>
     <p class="font-bold">【イメージ画像】</p>
-    <div class="ml-4 mt-2">
+    <div class="mt-2">
       <% if @world_guide.image.attached? %>
-        <a href="#" data-action="click->image-viewer#open" data-image-viewer-src-param="<%= url_for(@world_guide.image) %>">
-          <%= image_tag @world_guide.image, class: "max-w-md w-full h-auto rounded-lg shadow-md cursor-pointer hover:opacity-80 transition-opacity" %>
+        <a href="#" 
+           data-action="click->image-viewer#open" 
+           data-image-viewer-src-param="<%= url_for(@world_guide.image.variant(resize_to_limit: [1200, 1200])) %>">
+          <%= image_tag @world_guide.image.variant(resize_to_limit: [800, 800]), class: "w-full h-auto rounded-lg shadow-md cursor-pointer hover:opacity-80 transition-opacity" %>
         </a>
       <% else %>
-        <p class="text-xl">なし</p>
+        <p class="text-xl ml-4 mt-2">なし</p>
       <% end %>
     </div>
   </div>

--- a/app/views/world_guides/_form.html.erb
+++ b/app/views/world_guides/_form.html.erb
@@ -23,12 +23,16 @@
 
   <div data-controller="image-preview">
     <p class="block text-lg font-bold">イメージ画像</p>
+
     <div class="flex gap-4 mt-3 mb-10">
-      <%# スタイル付きのラベルをクリックすると、非表示のファイルフィールドが開く %>
-      <%= f.label :image, "ファイルから画像を追加", class: "w-1/2 py-2 text-center border border-gray-400 rounded-md cursor-pointer font-semibold hover:bg-black hover:text-white transition-colors" %>
-      <%= f.file_field :image, class: "hidden", data: { image_preview_target: "input", action: "change->image-preview#preview" } %>
-      
-      <button type="button" disabled class="w-1/2 py-2 border border-gray-400 rounded-md bg-gray-100 font-semibold text-gray-500">イメージ画像を見つける</button>
+      <div class="w-1/2">
+        <%= f.label :image, "ファイルから画像を追加", class: "w-full py-2 text-center border border-gray-400 rounded-md cursor-pointer font-semibold hover:bg-black hover:text-white transition-colors block" %>
+        <%= f.file_field :image, class: "hidden", data: { image_preview_target: "input", action: "change->image-preview#preview" } %>
+      </div>
+
+      <div class="w-1/2">
+        <button type="button" disabled class="w-full py-2 border border-gray-400 rounded-md bg-gray-100 font-semibold text-gray-500">イメージ画像を見つける</button>
+      </div>
     </div>
 
     <div class="mt-4">

--- a/app/views/world_guides/show.html.erb
+++ b/app/views/world_guides/show.html.erb
@@ -1,4 +1,11 @@
 <% breadcrumb :world_guide, @story, @world_guide %>
+
+<% if @world_guide.image.attached? %>
+  <% content_for :head do %>
+    <link rel="preload" as="image" href="<%= url_for(@world_guide.image.variant(resize_to_limit: [1200, 1200])) %>">
+  <% end %>
+<% end %>
+
 <div class="px-4 sm:px-6 lg:px-8 py-8 ">
   <div class="max-w-screen-xl mx-auto">
     <h1 class="text-center text-3xl md:text-4xl font-bold tracking-tight mt-12 mb-14">ワールドガイドを確認しよう！</h1>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -31,6 +31,7 @@ ja:
         world_name: "「 世界名 」"
         country_name: "「 国名 」"
         region_name: "「 地域名 」"
+        image: "イメージ画像"
       character:
         name: "名前"
         race: "種族"
@@ -39,6 +40,7 @@ ja:
         category: "カテゴリ"
         birthplace_world_guide_id: "出身地"
         address_world_guide_id: "現住所"
+        image: "イメージ画像"
 
   activemodel:
     attributes:
@@ -48,6 +50,18 @@ ja:
         category: "お問い合わせ種別"
         content: "お問い合わせ内容"
   
+  active_storage_validations:
+    messages:
+      content_type_invalid: "のファイル形式は不正です"
+      file_size_out_of_range: "のファイルサイズは%{min}から%{max}の間にしてください"
+      limit_out_of_range: "のファイル数は%{min}から%{max}の間にしてください"
+      image_size_out_of_range: "の画像サイズは%{min_width}x%{min_height}pxから%{max_width}x%{max_height}pxの間にしてください"
+      image_aspect_ratio_not_square: "は正方形にしてください"
+      image_aspect_ratio_not_portrait: "は縦長にしてください"
+      image_aspect_ratio_not_landscape: "は横長にしてください"
+      image_aspect_ratio_is_not: "のアスペクト比は%{aspect_ratio}にしてください"
+      image_aspect_ratio_in_range: "のアスペクト比は%{min_aspect_ratio}から%{max_aspect_ratio}の間にしてください"
+
   errors:
     format: "%{attribute}%{message}"
     messages:


### PR DESCRIPTION
## 概要
このissueでは、当初の「画像バリデーション実装」に加え、関連するUI/UXの改善とパフォーマンス向上も併せて実施しました。

1. 画像ファイルのバリデーション実装
active_storage_validations gemを導入し、CharacterとWorldGuideの両モデルにファイル形式（JPEG/PNG）とファイルサイズ（5MB未満）の検証ルールを追加しました。

2. フォームUIの改善
バリデーションエラー発生時に、Railsが自動生成する<div class="field_with_errors">が原因で画像アップロードボタンのレイアウトが崩れる問題がありました。

これを解決するため、ボタンをそれぞれ専用の `<div>` で囲むようにHTML構造を修正し、レイアウトの堅牢性を高めました。
